### PR TITLE
Make hepdata-converter-ws-client compatible with python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,11 @@ install:
 - sudo pip install coveralls
 - sudo pip install -r requirements.txt
 
+before_script:
+- docker run -d -p 0.0.0.0:8945:5000 hepdata-converter-ws
+
 script:
-- export CURRENT_PATH=`pwd`
-- docker run -v $CURRENT_PATH:$CURRENT_PATH hepdata/hepdata-converter-ws /bin/bash -c "cd $CURRENT_PATH && sudo pip install hepdata-converter-ws && coverage run -m unittest discover hepdata_converter_ws_client/testsuite 'test_*'"
+- coverage run -m unittest discover hepdata_converter_ws_client/testsuite 'test_*'
 
 after_success:
 - ls -al

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ install:
 
 before_script:
 - docker run -d -p 0.0.0.0:8945:5000 --name hepdata-converter-ws-tests hepdata/hepdata-converter-ws
-- docker ps
-- docker logs --details hepdata-converter-ws-tests
+- sleep 1
 
 script:
 - coverage run -m unittest discover hepdata_converter_ws_client/testsuite 'test_*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 - sudo pip install -r requirements.txt
 
 before_script:
-- docker run -d -p 0.0.0.0:8945:5000 hepdata-converter-ws
+- docker run -d -p 0.0.0.0:8945:5000 hepdata/hepdata-converter-ws
 
 script:
 - coverage run -m unittest discover hepdata_converter_ws_client/testsuite 'test_*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 - sudo pip install -r requirements.txt
 
 before_script:
-- docker run -d -p 0.0.0.0:8945:5000 hepdata/hepdata-converter-ws
+- docker run -d -p 0.0.0.0:8945:5000 --name hepdata-converter-ws-tests hepdata/hepdata-converter-ws
 
 script:
 - coverage run -m unittest discover hepdata_converter_ws_client/testsuite 'test_*'
@@ -22,6 +22,9 @@ after_success:
 - ls -al
 - coverage --version
 - coveralls
+
+after_failure:
+- docker logs --details hepdata-converter-ws-tests
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ after_success:
 after_failure:
 - docker logs --details hepdata-converter-ws-tests
 - docker ps
+- wget http://localhost:8945 || echo "wget failed"
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
 - '2.7'
+- '3.7'
 sudo: required
 cache:
 - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,6 @@ after_success:
 - coverage --version
 - coveralls
 
-after_failure:
-- docker logs --details hepdata-converter-ws-tests
-- docker ps
-- wget http://localhost:8945 || echo "wget failed"
-
 deploy:
   provider: pypi
   user: hepdata

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 install:
 - sudo pip install --upgrade pip
 - sudo pip install coveralls
-- sudo pip install -r requirements.txt
+- sudo pip install --ignore-installed -r requirements.txt
 
 before_script:
 - docker run -d -p 0.0.0.0:8945:5000 --name hepdata-converter-ws-tests hepdata/hepdata-converter-ws

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ after_success:
 
 after_failure:
 - docker logs --details hepdata-converter-ws-tests
+- docker ps
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ install:
 
 before_script:
 - docker run -d -p 0.0.0.0:8945:5000 --name hepdata-converter-ws-tests hepdata/hepdata-converter-ws
+- docker ps
+- docker logs --details hepdata-converter-ws-tests
 
 script:
 - coverage run -m unittest discover hepdata_converter_ws_client/testsuite 'test_*'

--- a/README.md
+++ b/README.md
@@ -106,9 +106,10 @@ file object, it's then responsibility of the user to decompress it)
 
 ```
 import hepdata_converter_ws_client
+from io import BytesIO
 # using path to input file, writing to output stream
 input_path = '/path/to/input.txt'
-output = StringIO.StringIO()
+output = BytesIO()
 hepdata_converter_ws_client.convert('http://hepdata-converter-ws-addr:port', input_path, output,
                                     options={'input_format': 'oldhepdata'}, extract=False)
 

--- a/hepdata_converter_ws_client/__init__.py
+++ b/hepdata_converter_ws_client/__init__.py
@@ -4,10 +4,9 @@ import json
 import os
 import requests
 import tarfile
-import cStringIO
 import tempfile
 import shutil
-import StringIO
+from io import StringIO
 
 __author__ = 'Michał Szostak'
 
@@ -60,7 +59,7 @@ def convert(url, input, output=None, options={}, id=None, extract=True):
     :return: Binary data containing tar.gz return type. value is returned from this function if and only if no output
     has been specified
     """
-    input_stream = cStringIO.StringIO()
+    input_stream = StringIO.StringIO()
     output_defined = output is not None
     if not output_defined:
         extract = False
@@ -97,7 +96,7 @@ def convert(url, input, output=None, options={}, id=None, extract=True):
 
     error_occurred = False
     try:
-        tarfile.open('r:gz', fileobj=cStringIO.StringIO(r.content)).close()
+        tarfile.open('r:gz', fileobj=StringIO.StringIO(r.content)).close()
     except tarfile.ReadError:
         error_occurred = True
 
@@ -107,7 +106,7 @@ def convert(url, input, output=None, options={}, id=None, extract=True):
 
         tmp_dir = tempfile.mkdtemp(suffix='hdc')
         try:
-            with tarfile.open('r:gz', fileobj=cStringIO.StringIO(r.content)) as tar:
+            with tarfile.open('r:gz', fileobj=StringIO.StringIO(r.content)) as tar:
                 tar.extractall(tmp_dir)
             content = os.listdir(tmp_dir)[0]
             shutil.move(os.path.join(tmp_dir, content), output)

--- a/hepdata_converter_ws_client/__init__.py
+++ b/hepdata_converter_ws_client/__init__.py
@@ -1,13 +1,12 @@
 # -*- encoding: utf-8 -*-
 import base64
-import gzip
 import json
 import os
 import requests
 import tarfile
 import tempfile
 import shutil
-from io import BytesIO, StringIO
+from io import BytesIO
 from builtins import str as text
 
 __author__ = 'Michał Szostak'
@@ -70,7 +69,7 @@ def convert(url, input, output=None, options={}, id=None, extract=True):
     archive_name = options.get('filename', ARCHIVE_NAME)
 
     # input is a path, treat is as such
-    if isinstance(input, str):
+    if isinstance(input, (str, text)):
         assert os.path.exists(input)
 
         with tarfile.open(mode='w:gz', fileobj=input_stream) as tar:
@@ -105,7 +104,7 @@ def convert(url, input, output=None, options={}, id=None, extract=True):
         error_occurred = True
 
     if extract and not error_occurred:
-        if not isinstance(output, str):
+        if not isinstance(output, (str, text)):
             raise ValueError('if extract=True then output must be path')
 
         tmp_dir = tempfile.mkdtemp(suffix='hdc')
@@ -117,7 +116,7 @@ def convert(url, input, output=None, options={}, id=None, extract=True):
         finally:
             shutil.rmtree(tmp_dir, ignore_errors=True)
     else:
-        if isinstance(output, str):
+        if isinstance(output, (str, text)):
             with open(output, 'wb') as f:
                 f.write(r.content)
         elif hasattr(output, 'write'):

--- a/hepdata_converter_ws_client/testsuite/__init__.py
+++ b/hepdata_converter_ws_client/testsuite/__init__.py
@@ -1,3 +1,20 @@
 # -*- encoding: utf-8 -*-
 
+from hepdata_converter.testsuite import construct_testdata_path
+
 __author__ = 'Michał Szostak'
+
+
+class insert_data_as_binary_file(object):
+    def __init__(self, *sample_file_name):
+        if len(sample_file_name) > 0:
+            self.sample_file_name = sample_file_name[0].split('/')
+
+    def __call__(self, function):
+        def _inner(*args, **kwargs):
+            args = list(args)
+            with open(construct_testdata_path(self.sample_file_name), 'rb') as f:
+                args.append(f)
+                function(*args, **kwargs)
+
+        return _inner

--- a/hepdata_converter_ws_client/testsuite/__init__.py
+++ b/hepdata_converter_ws_client/testsuite/__init__.py
@@ -1,14 +1,50 @@
 # -*- encoding: utf-8 -*-
 
-from hepdata_converter.testsuite import construct_testdata_path
-
 __author__ = 'Michał Szostak'
+
+import os
+from random import randint
+import shutil
+import tempfile
+import time
+import unittest
+import yaml
+
+# We try to load using the CSafeLoader for speed improvements.
+try:
+    from yaml import CSafeLoader as Loader
+except ImportError: #pragma: no cover
+    from yaml import SafeLoader as Loader #pragma: no cover
+
+
+def _parse_path_arguments(sample_file_name):
+    _sample_file_name = list(sample_file_name)
+    sample_file_name = []
+    for path_element in _sample_file_name:
+        sample_file_name += path_element.split('/')
+
+    return sample_file_name
+
+
+def construct_testdata_path(path_elements):
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), 'testdata', *path_elements)
+
+
+class TMPDirMixin(object):
+    def tearDown(self):
+        shutil.rmtree(self.current_tmp)
+
+    def setUp(self):
+        self.current_tmp = os.path.join(tempfile.gettempdir(), str(int(time.time()))) + str(randint(0, 10000))
+        try:
+            os.mkdir(self.current_tmp)
+        finally:
+            pass
 
 
 class insert_data_as_binary_file(object):
     def __init__(self, *sample_file_name):
-        if len(sample_file_name) > 0:
-            self.sample_file_name = sample_file_name[0].split('/')
+        self.sample_file_name = _parse_path_arguments(sample_file_name)
 
     def __call__(self, function):
         def _inner(*args, **kwargs):
@@ -18,3 +54,46 @@ class insert_data_as_binary_file(object):
                 function(*args, **kwargs)
 
         return _inner
+
+
+class insert_path(object):
+    def __init__(self, *sample_file_name):
+        self.sample_file_name = _parse_path_arguments(sample_file_name)
+
+    def __call__(self, function):
+        def _inner(*args, **kwargs):
+            args = list(args)
+            args.append(construct_testdata_path(self.sample_file_name))
+            function(*args, **kwargs)
+
+        return _inner
+
+
+class ExtendedTestCase(unittest.TestCase):
+    def assertMultiLineAlmostEqual(self, first, second, msg=None):
+        if hasattr(first, 'readlines'):
+            lines = first.readlines()
+        elif isinstance(first, (str, str)):
+            lines = first.split('\n')
+
+        if hasattr(second, 'readlines'):
+            orig_lines = second.readlines()
+        elif isinstance(second, (str, str)):
+            orig_lines = second.split('\n')
+
+        self.assertEqual(len(lines), len(orig_lines))
+        for i in range(len(lines)):
+            self.assertEqual(lines[i].strip(), orig_lines[i].strip())
+
+    def assertDirsEqual(self, first_dir, second_dir,
+                        file_content_parser=lambda x: list(yaml.load_all(x, Loader=Loader)),
+                        exclude=[], msg=None):
+        self.assertEqual(list(os.walk(first_dir))[1:], list(os.walk(second_dir))[1:], msg)
+        dirs = list(os.walk(first_dir))
+        for file in dirs[0][2]:
+            if file not in exclude:
+                with open(os.path.join(first_dir, file)) as f1, open(os.path.join(second_dir, file)) as f2:
+                    # separated into 2 variables to ease debugging if the need arises
+                    d1 = file_content_parser(f1.read())
+                    d2 = file_content_parser(f2.read())
+                    self.assertEqual(d1, d2)

--- a/hepdata_converter_ws_client/testsuite/test_setup.py
+++ b/hepdata_converter_ws_client/testsuite/test_setup.py
@@ -2,16 +2,16 @@
 import os
 import subprocess
 import sys
-from hepdata_converter.testsuite.test_writer import WriterTestSuite
+
+from hepdata_converter_ws_client.testsuite import TMPDirMixin
 
 __author__ = 'Michał Szostak'
 
 import unittest
 
 
-class SetupTestCase(WriterTestSuite):
+class SetupTestCase(TMPDirMixin, unittest.TestCase):
     def test_setup(self):
-        # specyfing root is a hack, without it --dry-run still fails because of ACL
-        # r = subprocess.call([sys.executable, 'setup.py', '--dry-run', 'install', '--root', self.current_tmp])
-        # self.assertEqual(r, 0)
-        pass
+        # Test installation in a temp directory
+        r = subprocess.call([sys.executable, 'setup.py', 'install', '--root', self.current_tmp])
+        self.assertEqual(r, 0)

--- a/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/sample.input
+++ b/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/sample.input
@@ -1,0 +1,308 @@
+# Sample input file for new HepData submissions.
+# Annotated version of http://hepdata.cedar.ac.uk/view/ins1203852/input
+# See resulting HepData record at http://hepdata.cedar.ac.uk/view/ins1203852
+# Any text after # in a line is treated as a comment and will be ignored.
+# Keywords are indicated by an asterisk (*) at the start of a line.
+
+# Test data input at http://hepdata.cedar.ac.uk/input
+# by clicking on "Browse..." to select your input file, followed by
+# "Upload" and "Process", then click "Display" for the first 10 tables,
+# or "All" for the whole record.
+# See http://hepdata.cedar.ac.uk/submittingdata for further information.
+
+# Give surname (in capital letters) of first author of associated paper.
+*author: AAD
+
+# Give references ending in a colon followed by the year.
+# Omit the journal reference if the paper is not yet published.
+*reference: ARXIV:1211.6096 : 2012 # arXiv number
+*reference: CERN-PH-EP-2012-318 : 2012 # preprint number
+*reference: JHEP 1303,128 (2013) : 2013 # journal reference
+
+# Give web link to auxiliary information if available.
+# The line must also end with a colon followed by the year.
+*reference: http://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/STDM-2012-02/ : 2012
+
+# Give DOI of journal publication if available.
+*doi: 10.1007/JHEP03(2013)128
+
+# Give date and person who encoded the record
+# (could include collaboration, e-mail address etc.).
+# Please give the full name of the encoder and not
+# just their initials (with collaboration in brackets).
+*status: Encoded 27 FEB 2014 by Graeme Watt
+# Can add other entries if record is later modified.
+# The first word "Encoded" or "Modified" will be stored.
+*status: Modified 30 APR 2014 by Graeme Watt
+# If using the automated submission system, could add name
+# of Administrator as well as Encoder, e.g. "Checked by ...".
+# The *status information is printed at the bottom of each HTML record.
+
+# Give "Laboratory-Accelerator-Experiment" and Detector.
+*experiment: CERN-LHC-ATLAS
+*detector: ATLAS
+
+# SPIRES (http://www.slac.stanford.edu/spires/) record number.
+# Will not be allocated for new papers: superseded by INSPIRE.
+*spiresId: 9863591
+
+# INSPIRE (http://inspirehep.net/) record number.
+*inspireId: 1203852
+
+# CERN Document Server (http://cds.cern.ch/) record number.
+*cdsId: 1496097
+
+# Internal Durham record number (will be assigned after submission).
+*durhamId: 6150
+
+# Title of associated paper.
+*title: Measurement of ZZ production in pp collisions at sqrt(s) = 7 TeV and limits on anomalous ZZZ and ZZgamma couplings with the ATLAS detector
+
+# Comments describing the data as a whole.  Start with "Laboratory-Accelerator".
+# Remainder is a plain-text summary of the presented measurements.  This is
+# generally close to the paper abstract, but with more focus on the measurement.
+# For example, information on data interpretation and comparison to theory can
+# be removed (unless this information is to appear in the HepData record).
+# Additional information concerning the whole data set can appear here.
+# Line breaks are preserved in the HTML display.  A full stop is automatically
+# inserted at the end of the comment, so it should be omitted here.
+
+*comment: CERN-LHC.  Measurements of the cross section for ZZ production using the 4l and 2l2nu decay channels in proton-proton collisions at a centre-of-mass energy of 7 TeV with 4.6 fb^-1 of data collected in 2011.  The final states used are 4 electrons, 4 muons, 2 electrons and 2 muons, 2 electrons and missing transverse momentum, and 2 muons and missing transverse momentum (MET).
+
+The cross section values reported in the tables should be multiplied by a factor of 1.0141 to take into account the updated value of the integrated luminosity for the ATLAS 2011 data taking period.  The uncertainty on the global normalisation ("Lumi") remains at 1.8%.  See Eur.Phys.J. C73 (2013) 2518 for more details.
+
+The 4l channel fiducial region is defined as:
+- 4e, 4mu or 2e2mu
+- Ambiguities in pairing are resolved by choosing the combination that results in the smaller value of the sum |mll - mZ| for the two pairs, where mll is the mass of the dilepton system.
+- ptLepton > 7 GeV (at least one with ptLepton > 20 (25) GeV for muons (electrons))
+- |etaLepton| < 3.16
+- At least one lepton pair is required to have invariant mass between 66 and 116 GeV. If the second pair also satisfies this, the event is ZZ, otherwise if the second pair satisfies mll > 20 GeV it is ZZ*.
+- min(DeltaR(l,l)) > 0.2.
+
+The 2l2nu channel fiducial region is defined as:
+- 2e+MET or 2mu+MET
+- ptLepton > 20 GeV
+- |etaLepton| < 2.5
+- mll must be between 76 and 106 GeV
+- -MET*cos(phi_METZ)>75 GeV, where phi_METZ is the angle between the Z and the MET
+- |MET - pTZ| / pTZ < 0.4, where pTZ is the transverse momentum of the dilepton system
+- No events with a jet for which ptJet > 25 GeV and |etaJet| < 4.5
+- No events with a third lepton for which ptLepton > 10 GeV
+- min(DeltaR(l,l)) > 0.3
+
+
+# Note that much of the metadata above can be obtained by entering the
+# Inspire ID or arXiv number for the paper in the text box adjacent to
+# the "Get started" button.
+
+# Remainder of file provides information on each table.  All records should
+# have at least one table, even for single-number measurements where all
+# relevant information is given in the abstract.
+
+# Note that much of the HepData notation is historical and originates from
+# 1970s guidelines for use with the Berkeley Database Management System (BDMS):
+#   http://hepdata.cedar.ac.uk/resource/EncodingManual.pdf
+# You can look at existing HepData records to get some idea of the format.
+# LaTeX mathematical expressions are now supported via MathJax.
+
+# Use "*dataset:" to indicate the start of a table.
+*dataset:
+
+# Give location of relevant data in paper (e.g. "Figure 8A", "Table 3" etc.).
+*location: Page 17 of preprint
+
+# Comments on this particular table.  This is generally close to the caption of
+# the associated figure/table in the paper, but it should not refer to missing
+# information such as theoretical predictions (unless they are also given as
+# numbers in the table).  A full stop is automatically inserted at the end of
+# the dscomment, so it should be omitted here.
+*dscomment: The measured fiducial cross sections.  The first systematic uncertainty is the combined systematic uncertainty excluding luminosity, the second is the luminosity
+
+# The main process under study, used by the online search facility.
+# The *reackey can be omitted if there is not a specific process.
+# Multiple *reackey processes can be given on separate lines.
+# Do not attempt to give multiple processes on the same line.
+# Omit the decay products or give them on a separate line.
+*reackey: P P --> Z0 Z0 X
+# The reaction should always have an initial state and a final state
+# separated by "-->".  The right-hand side should usually have an "X" to
+# indicate an inclusive reaction (as opposed to exclusive where all
+# final-state particles are known, e.g. elastic proton scattering).
+
+# The particular type of measurement or observable, used by the online search.
+# Use "SIG" for a cross section, "DSIG/DPT" for a differential cross section,
+# "N" for number of events, etc.  See:  http://hepdata.cedar.ac.uk/browse
+# Avoid adding new values not already in the database, found by browsing 
+# or searching for "obs OBSKEY" on the main HepData webpage.  If in doubt,
+# just omit the *obskey statement completely.  The *obskey value must consist
+# of only a single word, but multiple values can be given on separate lines.
+*obskey: SIG
+
+# There are usually multiple lines beginning with "*qual:" giving the reaction
+# (as below), the centre-of-mass energy, and important kinematic cuts.
+# Here, the three columns of the table correspond to different final states.
+# Decay products of the final-state particles are indicated by angular brackets.
+*qual: RE : P P --> Z0 < LEPTON+ LEPTON- > Z0 < LEPTON+ LEPTON- > X : P P --> Z0 < LEPTON+ LEPTON- > Z0* < LEPTON+ LEPTON- > X : P P --> Z0 < LEPTON+ LEPTON- > Z0 < NU NUBAR > X
+
+# Headers for the x columns separated by colons ":" (only one in this case).
+*xheader: SQRT(S) IN GEV 
+
+# Headers for the y columns separated by ":" (here, header spans three columns).
+*yheader: SIG(fiducial) IN FB
+
+# The *xheader and *yheader should always be present and should describe the
+# quantities in the table.  Generally these will correspond to the labels of
+# the x and y axis of the corresponding plot in the paper.  Qualifiers (*qual)
+# are optional and can distinguish results given in different columns.  Always
+# try to give the units of any variable that appears in the qualifiers or
+# headers in the form "name IN units".  Each table should usually contain a
+# qualifier giving the centre-of-mass energy (unless it appears as the x
+# variable), e.g. "*qual: SQRT(S)/NUCLEON IN GEV : 7.7".
+
+# Specify number of columns separated by ":" (here, 1 "x" and 3 "y" columns).
+*data: x : y : y : y 
+
+# Now give the numerical values for the data, separating columns by a
+# semicolon (";") and also terminating each line by a semicolon (";").
+# Non-existent entries can be indicated by dashes "-".
+# Numerical values should be given with an appropriate and not excessive number
+# of significant figures (in general, a maximum of 4), avoiding giving more
+# decimal places for the errors than the central values.
+# After the central value, give the statistical uncertainties followed by the
+# (possibly multiple) systematic uncertainties in brackets as shown below.
+# A label can be given to distinguish multiple systematic uncertainties, as
+# shown below for the "lumi" case, by a colon after the number, then the label.
+# For asymmetric errors, always give the "plus" error before the "minus" error.
+
+ 7000; 25.4 +3.3,-3.0 (DSYS=+1.2,-1.0,DSYS=1.0:lumi); 29.8 +3.8,-3.5 (DSYS=+1.7,-1.5,DSYS=1.2:lumi); 12.7 +3.1,-2.9 (DSYS=1.7,DSYS=0.5:lumi);
+
+# Use "*dataend:" to indicate the end of a table (optional, can be omitted,
+# provided that "*E" is used at the end of the input file).
+*dataend:
+
+
+# Similarly for Table 2 ...
+*dataset:
+*location: Page 20 of preprint
+*dscomment: The measured total cross sections.  The first systematic uncertainty is the combined systematic uncertainty excluding luminosity, the second is the luminosity
+*reackey: P P --> Z0 Z0 X
+*obskey: SIG
+*qual: RE : P P --> Z0 Z0 X
+*yheader: SIG(total) IN FB
+*xheader: SQRT(S) IN GEV 
+*data: x : y 
+ 7000; 6.7 +- 0.7 (DSYS=+0.4,-0.3,DSYS=0.3:lumi);
+*dataend:
+
+
+# Similarly for Table 3 ...
+# Note units of GEV not GEV/C (i.e. C = 1) for transverse momentum PT.
+# The x values are given as the bin centre (not necessarily equal to midpoint)
+# followed by the lower and upper limits of the bin.  In the common case that
+# the bin centre is equal to the midpoint, then it can be omitted,
+# i.e. just " 0 TO 60;" instead of " 30 (BIN=0 TO 60);".  Note that the
+# formatter currently appends an unnecessary ".0" to some integers, as below.
+*dataset:
+*location: Figure 8A
+*dscomment: Normalized ZZ fiducial cross section (multiplied by 10^6 for readability) in bins of the leading reconstructed dilepton pT for the 4 lepton channel.  The first systematic uncertainty is detector systematics, the second is background systematic uncertainties
+*reackey: P P --> Z0 Z0 X
+*obskey: DSIG/DPT
+*qual: RE : P P --> Z0 < LEPTON+ LEPTON- > Z0 < LEPTON+ LEPTON- > X
+*qual: SQRT(S) IN GEV : 7000.0
+*yheader: 10**6 * 1/SIG(fiducial) * D(SIG(fiducial))/DPT IN GEV**-1
+*xheader: Leading dilepton PT IN GEV
+*data: x : y 
+ 0.0 TO 60.0; 7000 +- 1100.0 (DSYS=79.0:detector,DSYS=15.0:background);
+ 60.0 TO 100.0; 9800 +- 1600.0 (DSYS=75.0:detector,DSYS=15.0:background);
+ 100.0 TO 200.0; 1600 +- 490.0 (DSYS=41.0:detector,DSYS=2.0:background);
+ 200.0 TO 600.0; 80 +- 60.0 (DSYS=2.0:detector,DSYS=0.0:background);
+*dataend:
+
+# Similarly for Table 4 ...
+*dataset:
+*location: Figure 8B
+*dscomment: Normalized ZZ fiducial cross section (multiplied by 10^6 for readability) in bins of the dilepton pT for the 2l2nu channel.  The first systematic uncertainty is detector systematics, the second is background systematic uncertainties
+*reackey: P P --> Z0 Z0 X
+*obskey: DSIG/DPT
+*qual: RE : P P --> Z0 < LEPTON+ LEPTON- > Z0 < NU NUBAR > X
+*qual: SQRT(S) IN GEV : 7000.0
+*yheader: 10**6 * 1/SIG(fiducial) * D(SIG(fiducial))/DPT IN GEV**-1
+*xheader: Leading dilepton PT IN GEV 
+*data: x : y 
+ 50.0 TO 90.0; 9930 +- 3340.0 (DSYS=80.0:detector,DSYS=740.0:background);
+ 90.0 TO 130.0; 8280 +- 3210.0 (DSYS=200.0:detector,DSYS=260.0:background);
+ 130.0 TO 200.0; 3900 +- 1490.0 (DSYS=120.0:detector,DSYS=390.0:background);
+*dataend:
+
+# Similarly for Table 5 ...
+*dataset:
+*location: Figure 9A
+*dscomment: Normalized ZZ fiducial cross section (multiplied by 10^6 for readability) in bins of deltaPhi between the two leptons of the leading dileptons for the 4l channel.  The first systematic uncertainty is detector systematics, the second is background systematic uncertainties.
+UPDATE (30 APR 2014): extra significant digit added for first bin
+*reackey: P P --> Z0 Z0 X
+*obskey: DSIG/DPHI
+*qual: RE : P P --> Z0 < LEPTON+ LEPTON- > Z0 < LEPTON+ LEPTON- > X
+*qual: SQRT(S) IN GEV : 7000.0
+*yheader: 10**6 * 1/SIG(fiducial) * D(SIG(fiducial))/DDELTA(PHI(LEPTON+,LEPTON-))
+*xheader: Leading dilepton DELTA(PHI(LEPTON+,LEPTON-)) 
+*data: x : y 
+ 0.0 TO 0.5; 130000 +- 69000.0 (DSYS=6600.0:detector,DSYS=10.0:background);
+ 0.5 TO 1.0; 280000 +- 100000.0 (DSYS=9000.0:detector,DSYS=400.0:background);
+ 1.0 TO 1.7; 260000 +- 80000.0 (DSYS=10000.0:detector,DSYS=300.0:background);
+ 1.7 TO 3.14159; 420000 +- 50000.0 (DSYS=2000.0:detector,DSYS=300.0:background);
+*dataend:
+
+# Similarly for Table 6 ...
+*dataset:
+*location: Figure 9B
+*dscomment: Normalized ZZ fiducial cross section (multiplied by 10^6 for readability) in bins of deltaPhi between the two leptons for the 2l2nu channel.  The first systematic uncertainty is detector systematics, the second is background systematic uncertainties
+*reackey: P P --> Z0 Z0 X
+*obskey: DSIG/DPHI
+*qual: RE : P P --> Z0 < LEPTON+ LEPTON- > Z0 < NU NUBAR > X
+*qual: SQRT(S) IN GEV : 7000.0
+*yheader: 10**6 * 1/SIG(fiducial) * D(SIG(fiducial))/DDELTA(PHI(LEPTON+,LEPTON-))
+*xheader: Leading dilepton DELTA(PHI(LEPTON+,LEPTON-)) 
+*data: x : y 
+ 0.0 TO 0.5; 346000 +- 158000.0 (DSYS=4000.0:detector,DSYS=19000.0:background);
+ 0.5 TO 1.7; 569000 +- 91000.0 (DSYS=4000.0:detector,DSYS=71000.0:background);
+ 1.7 TO 3.14159; 100000 +- 70000.0 (DSYS=2000.0:detector,DSYS=58000.0:background);
+*dataend:
+
+# Similarly for Table 7 ...
+*dataset:
+*location: Figure 10A
+*dscomment: Normalized ZZ fiducial cross section (multiplied by 10^6 for readability) in bins of the mass of the ZZ system for the 4l channel.  The first systematic uncertainty is detector systematics, the second is background systematic uncertainties
+*reackey: P P --> Z0 Z0 X
+*obskey: DSIG/DM
+*qual: RE : P P --> Z0 < LEPTON+ LEPTON- > Z0 < LEPTON+ LEPTON- > X
+*qual: SQRT(S) IN GEV : 7000.0
+*yheader: 10**6 * 1/SIG(fiducial) * D(SIG(fiducial))/DM(ZZ)
+*xheader: M(ZZ) IN GEV 
+*data: x : y 
+ 0.0 TO 240.0; 2200 +- 300.0 (DSYS=40.0:detector,DSYS=2.0:background);
+ 240.0 TO 300.0; 4500 +- 1000.0 (DSYS=100.0:detector,DSYS=5.0:background);
+ 300.0 TO 400.0; 1000 +- 400.0 (DSYS=20.0:detector,DSYS=2.0:background);
+ 400.0 TO 800.0; 280 +- 100.0 (DSYS=10.0:detector,DSYS=1.0:background);
+*dataend:
+
+# Similarly for Table 8 ...
+*dataset:
+*location: Figure 10B
+*dscomment: Normalized ZZ fiducial cross section (multiplied by 10^6 for readability) in bins of the transverse mass of the ZZ system for the 2l2nu channel.  The first systematic uncertainty is detector systematics, the second is background systematic uncertainties
+*reackey: P P --> Z0 Z0 X
+*obskey: DSIG/DM
+*qual: RE : P P --> Z0 < LEPTON+ LEPTON- > Z0 < NU NUBAR > X
+*qual: SQRT(S) IN GEV : 7000.0
+*yheader: 10**6 * 1/SIG(fiducial) * D(SIG(fiducial))/DMT(ZZ)
+*xheader: MT(ZZ) IN GEV 
+*data: x : y 
+ 220.0 TO 250.0; 10500 +- 4400.0 (DSYS=300.0:detector,DSYS=1900.0:background);
+ 250.0 TO 300.0; 6320 +- 2630.0 (DSYS=230.0:detector,DSYS=280.0:background);
+ 300.0 TO 400.0; 3680 +- 1210.0 (DSYS=60.0:detector,DSYS=480.0:background);
+*dataend:
+
+
+# Use "*E" to denote the end of the input file (optional, can be omitted,
+# provided that "*dataend:" is used above).
+
+*E

--- a/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data1.yaml
+++ b/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data1.yaml
@@ -1,0 +1,37 @@
+dependent_variables:
+- header: {name: SIG(fiducial), units: FB}
+  qualifiers:
+  - {name: RE, value: P P --> Z0 < LEPTON+ LEPTON- > Z0 < LEPTON+ LEPTON- > X}
+  values:
+  - errors:
+    - asymerror: {minus: '-3.0', plus: '3.3'}
+      label: stat
+    - asymerror: {minus: '-1.0', plus: '1.2'}
+      label: sys
+    - {label: 'sys,lumi', symerror: '1.0'}
+    value: '25.4'
+- header: {name: SIG(fiducial), units: FB}
+  qualifiers:
+  - {name: RE, value: P P --> Z0 < LEPTON+ LEPTON- > Z0* < LEPTON+ LEPTON- > X}
+  values:
+  - errors:
+    - asymerror: {minus: '-3.5', plus: '3.8'}
+      label: stat
+    - asymerror: {minus: '-1.5', plus: '1.7'}
+      label: sys
+    - {label: 'sys,lumi', symerror: '1.2'}
+    value: '29.8'
+- header: {name: SIG(fiducial), units: FB}
+  qualifiers:
+  - {name: RE, value: P P --> Z0 < LEPTON+ LEPTON- > Z0 < NU NUBAR > X}
+  values:
+  - errors:
+    - asymerror: {minus: '-2.9', plus: '3.1'}
+      label: stat
+    - {label: sys, symerror: '1.7'}
+    - {label: 'sys,lumi', symerror: '0.5'}
+    value: '12.7'
+independent_variables:
+- header: {name: SQRT(S), units: GEV}
+  values:
+  - {value: '7000'}

--- a/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data2.yaml
+++ b/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data2.yaml
@@ -1,0 +1,15 @@
+dependent_variables:
+- header: {name: SIG(total), units: FB}
+  qualifiers:
+  - {name: RE, value: P P --> Z0 Z0 X}
+  values:
+  - errors:
+    - {label: stat, symerror: '0.7'}
+    - asymerror: {minus: '-0.3', plus: '0.4'}
+      label: sys
+    - {label: 'sys,lumi', symerror: '0.3'}
+    value: '6.7'
+independent_variables:
+- header: {name: SQRT(S), units: GEV}
+  values:
+  - {value: '7000'}

--- a/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data3.yaml
+++ b/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data3.yaml
@@ -1,0 +1,33 @@
+dependent_variables:
+- header: {name: 10**6 * 1/SIG(fiducial) * D(SIG(fiducial))/DPT, units: GEV**-1}
+  qualifiers:
+  - {name: RE, value: P P --> Z0 < LEPTON+ LEPTON- > Z0 < LEPTON+ LEPTON- > X}
+  - {name: SQRT(S), units: GEV, value: '7000.0'}
+  values:
+  - errors:
+    - {label: stat, symerror: '1100.0'}
+    - {label: 'sys,detector', symerror: '79.0'}
+    - {label: 'sys,background', symerror: '15.0'}
+    value: '7000'
+  - errors:
+    - {label: stat, symerror: '1600.0'}
+    - {label: 'sys,detector', symerror: '75.0'}
+    - {label: 'sys,background', symerror: '15.0'}
+    value: '9800'
+  - errors:
+    - {label: stat, symerror: '490.0'}
+    - {label: 'sys,detector', symerror: '41.0'}
+    - {label: 'sys,background', symerror: '2.0'}
+    value: '1600'
+  - errors:
+    - {label: stat, symerror: '60.0'}
+    - {label: 'sys,detector', symerror: '2.0'}
+    - {label: 'sys,background', symerror: '0.0'}
+    value: '80'
+independent_variables:
+- header: {name: Leading dilepton PT, units: GEV}
+  values:
+  - {high: 60.0, low: 0.0}
+  - {high: 100.0, low: 60.0}
+  - {high: 200.0, low: 100.0}
+  - {high: 600.0, low: 200.0}

--- a/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data4.yaml
+++ b/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data4.yaml
@@ -1,0 +1,27 @@
+dependent_variables:
+- header: {name: 10**6 * 1/SIG(fiducial) * D(SIG(fiducial))/DPT, units: GEV**-1}
+  qualifiers:
+  - {name: RE, value: P P --> Z0 < LEPTON+ LEPTON- > Z0 < NU NUBAR > X}
+  - {name: SQRT(S), units: GEV, value: '7000.0'}
+  values:
+  - errors:
+    - {label: stat, symerror: '3340.0'}
+    - {label: 'sys,detector', symerror: '80.0'}
+    - {label: 'sys,background', symerror: '740.0'}
+    value: '9930'
+  - errors:
+    - {label: stat, symerror: '3210.0'}
+    - {label: 'sys,detector', symerror: '200.0'}
+    - {label: 'sys,background', symerror: '260.0'}
+    value: '8280'
+  - errors:
+    - {label: stat, symerror: '1490.0'}
+    - {label: 'sys,detector', symerror: '120.0'}
+    - {label: 'sys,background', symerror: '390.0'}
+    value: '3900'
+independent_variables:
+- header: {name: Leading dilepton PT, units: GEV}
+  values:
+  - {high: 90.0, low: 50.0}
+  - {high: 130.0, low: 90.0}
+  - {high: 200.0, low: 130.0}

--- a/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data5.yaml
+++ b/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data5.yaml
@@ -1,0 +1,33 @@
+dependent_variables:
+- header: {name: '10**6 * 1/SIG(fiducial) * D(SIG(fiducial))/DDELTA(PHI(LEPTON+,LEPTON-))'}
+  qualifiers:
+  - {name: RE, value: P P --> Z0 < LEPTON+ LEPTON- > Z0 < LEPTON+ LEPTON- > X}
+  - {name: SQRT(S), units: GEV, value: '7000.0'}
+  values:
+  - errors:
+    - {label: stat, symerror: '69000.0'}
+    - {label: 'sys,detector', symerror: '6600.0'}
+    - {label: 'sys,background', symerror: '10.0'}
+    value: '130000'
+  - errors:
+    - {label: stat, symerror: '100000.0'}
+    - {label: 'sys,detector', symerror: '9000.0'}
+    - {label: 'sys,background', symerror: '400.0'}
+    value: '280000'
+  - errors:
+    - {label: stat, symerror: '80000.0'}
+    - {label: 'sys,detector', symerror: '10000.0'}
+    - {label: 'sys,background', symerror: '300.0'}
+    value: '260000'
+  - errors:
+    - {label: stat, symerror: '50000.0'}
+    - {label: 'sys,detector', symerror: '2000.0'}
+    - {label: 'sys,background', symerror: '300.0'}
+    value: '420000'
+independent_variables:
+- header: {name: 'Leading dilepton DELTA(PHI(LEPTON+,LEPTON-))'}
+  values:
+  - {high: 0.5, low: 0.0}
+  - {high: 1.0, low: 0.5}
+  - {high: 1.7, low: 1.0}
+  - {high: 3.14159, low: 1.7}

--- a/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data6.yaml
+++ b/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data6.yaml
@@ -1,0 +1,27 @@
+dependent_variables:
+- header: {name: '10**6 * 1/SIG(fiducial) * D(SIG(fiducial))/DDELTA(PHI(LEPTON+,LEPTON-))'}
+  qualifiers:
+  - {name: RE, value: P P --> Z0 < LEPTON+ LEPTON- > Z0 < NU NUBAR > X}
+  - {name: SQRT(S), units: GEV, value: '7000.0'}
+  values:
+  - errors:
+    - {label: stat, symerror: '158000.0'}
+    - {label: 'sys,detector', symerror: '4000.0'}
+    - {label: 'sys,background', symerror: '19000.0'}
+    value: '346000'
+  - errors:
+    - {label: stat, symerror: '91000.0'}
+    - {label: 'sys,detector', symerror: '4000.0'}
+    - {label: 'sys,background', symerror: '71000.0'}
+    value: '569000'
+  - errors:
+    - {label: stat, symerror: '70000.0'}
+    - {label: 'sys,detector', symerror: '2000.0'}
+    - {label: 'sys,background', symerror: '58000.0'}
+    value: '100000'
+independent_variables:
+- header: {name: 'Leading dilepton DELTA(PHI(LEPTON+,LEPTON-))'}
+  values:
+  - {high: 0.5, low: 0.0}
+  - {high: 1.7, low: 0.5}
+  - {high: 3.14159, low: 1.7}

--- a/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data7.yaml
+++ b/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data7.yaml
@@ -1,0 +1,33 @@
+dependent_variables:
+- header: {name: 10**6 * 1/SIG(fiducial) * D(SIG(fiducial))/DM(ZZ)}
+  qualifiers:
+  - {name: RE, value: P P --> Z0 < LEPTON+ LEPTON- > Z0 < LEPTON+ LEPTON- > X}
+  - {name: SQRT(S), units: GEV, value: '7000.0'}
+  values:
+  - errors:
+    - {label: stat, symerror: '300.0'}
+    - {label: 'sys,detector', symerror: '40.0'}
+    - {label: 'sys,background', symerror: '2.0'}
+    value: '2200'
+  - errors:
+    - {label: stat, symerror: '1000.0'}
+    - {label: 'sys,detector', symerror: '100.0'}
+    - {label: 'sys,background', symerror: '5.0'}
+    value: '4500'
+  - errors:
+    - {label: stat, symerror: '400.0'}
+    - {label: 'sys,detector', symerror: '20.0'}
+    - {label: 'sys,background', symerror: '2.0'}
+    value: '1000'
+  - errors:
+    - {label: stat, symerror: '100.0'}
+    - {label: 'sys,detector', symerror: '10.0'}
+    - {label: 'sys,background', symerror: '1.0'}
+    value: '280'
+independent_variables:
+- header: {name: M(ZZ), units: GEV}
+  values:
+  - {high: 240.0, low: 0.0}
+  - {high: 300.0, low: 240.0}
+  - {high: 400.0, low: 300.0}
+  - {high: 800.0, low: 400.0}

--- a/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data8.yaml
+++ b/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/data8.yaml
@@ -1,0 +1,27 @@
+dependent_variables:
+- header: {name: 10**6 * 1/SIG(fiducial) * D(SIG(fiducial))/DMT(ZZ)}
+  qualifiers:
+  - {name: RE, value: P P --> Z0 < LEPTON+ LEPTON- > Z0 < NU NUBAR > X}
+  - {name: SQRT(S), units: GEV, value: '7000.0'}
+  values:
+  - errors:
+    - {label: stat, symerror: '4400.0'}
+    - {label: 'sys,detector', symerror: '300.0'}
+    - {label: 'sys,background', symerror: '1900.0'}
+    value: '10500'
+  - errors:
+    - {label: stat, symerror: '2630.0'}
+    - {label: 'sys,detector', symerror: '230.0'}
+    - {label: 'sys,background', symerror: '280.0'}
+    value: '6320'
+  - errors:
+    - {label: stat, symerror: '1210.0'}
+    - {label: 'sys,detector', symerror: '60.0'}
+    - {label: 'sys,background', symerror: '480.0'}
+    value: '3680'
+independent_variables:
+- header: {name: MT(ZZ), units: GEV}
+  values:
+  - {high: 250.0, low: 220.0}
+  - {high: 300.0, low: 250.0}
+  - {high: 400.0, low: 300.0}

--- a/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/submission.yaml
+++ b/hepdata_converter_ws_client/testsuite/testdata/oldhepdata/yaml/submission.yaml
@@ -1,0 +1,174 @@
+additional_resources:
+- {description: web page with auxiliary material, location: 'http://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/STDM-2012-02/'}
+comment: |-
+  CERN-LHC.  Measurements of the cross section for ZZ production using the 4l and 2l2nu decay channels in proton-proton collisions at a centre-of-mass energy of 7 TeV with 4.6 fb^-1 of data collected in 2011.  The final states used are 4 electrons, 4 muons, 2 electrons and 2 muons, 2 electrons and missing transverse momentum, and 2 muons and missing transverse momentum (MET).
+
+  The cross section values reported in the tables should be multiplied by a factor of 1.0141 to take into account the updated value of the integrated luminosity for the ATLAS 2011 data taking period.  The uncertainty on the global normalisation ("Lumi") remains at 1.8%.  See Eur.Phys.J. C73 (2013) 2518 for more details.
+
+  The 4l channel fiducial region is defined as:
+  - 4e, 4mu or 2e2mu
+  - Ambiguities in pairing are resolved by choosing the combination that results in the smaller value of the sum |mll - mZ| for the two pairs, where mll is the mass of the dilepton system.
+  - ptLepton > 7 GeV (at least one with ptLepton > 20 (25) GeV for muons (electrons))
+  - |etaLepton| < 3.16
+  - At least one lepton pair is required to have invariant mass between 66 and 116 GeV. If the second pair also satisfies this, the event is ZZ, otherwise if the second pair satisfies mll > 20 GeV it is ZZ*.
+  - min(DeltaR(l,l)) > 0.2.
+
+  The 2l2nu channel fiducial region is defined as:
+  - 2e+MET or 2mu+MET
+  - ptLepton > 20 GeV
+  - |etaLepton| < 2.5
+  - mll must be between 76 and 106 GeV
+  - -MET*cos(phi_METZ)>75 GeV, where phi_METZ is the angle between the Z and the MET
+  - |MET - pTZ| / pTZ < 0.4, where pTZ is the transverse momentum of the dilepton system
+  - No events with a jet for which ptJet > 25 GeV and |etaJet| < 4.5
+  - No events with a third lepton for which ptLepton > 10 GeV
+  - min(DeltaR(l,l)) > 0.3.
+record_ids:
+- {id: 9863591, type: spires}
+- {id: 1203852, type: inspire}
+- {id: 1496097, type: cds}
+- {id: 6150, type: durham}
+---
+additional_resources: []
+data_file: data1.yaml
+data_license: {description: null, name: null, url: null}
+description: The measured fiducial cross sections.  The first systematic uncertainty
+  is the combined systematic uncertainty excluding luminosity, the second is the luminosity.
+keywords:
+- name: reactions
+  values: [P P --> Z0 Z0 X]
+- name: observables
+  values: [SIG]
+- name: phrases
+  values: []
+- name: cmenergies
+  values: [7000.0]
+location: Data from Page 17 of preprint
+name: Table 1
+---
+additional_resources: []
+data_file: data2.yaml
+data_license: {description: null, name: null, url: null}
+description: The measured total cross sections.  The first systematic uncertainty
+  is the combined systematic uncertainty excluding luminosity, the second is the luminosity.
+keywords:
+- name: reactions
+  values: [P P --> Z0 Z0 X]
+- name: observables
+  values: [SIG]
+- name: phrases
+  values: []
+- name: cmenergies
+  values: [7000.0]
+location: Data from Page 20 of preprint
+name: Table 2
+---
+additional_resources: []
+data_file: data3.yaml
+data_license: {description: null, name: null, url: null}
+description: Normalized ZZ fiducial cross section (multiplied by 10^6 for readability)
+  in bins of the leading reconstructed dilepton pT for the 4 lepton channel.  The
+  first systematic uncertainty is detector systematics, the second is background systematic
+  uncertainties.
+keywords:
+- name: reactions
+  values: [P P --> Z0 Z0 X]
+- name: observables
+  values: [DSIG/DPT]
+- name: phrases
+  values: []
+- name: cmenergies
+  values: [7000.0]
+location: Data from Figure 8A
+name: Table 3
+---
+additional_resources: []
+data_file: data4.yaml
+data_license: {description: null, name: null, url: null}
+description: Normalized ZZ fiducial cross section (multiplied by 10^6 for readability)
+  in bins of the dilepton pT for the 2l2nu channel.  The first systematic uncertainty
+  is detector systematics, the second is background systematic uncertainties.
+keywords:
+- name: reactions
+  values: [P P --> Z0 Z0 X]
+- name: observables
+  values: [DSIG/DPT]
+- name: phrases
+  values: []
+- name: cmenergies
+  values: [7000.0]
+location: Data from Figure 8B
+name: Table 4
+---
+additional_resources: []
+data_file: data5.yaml
+data_license: {description: null, name: null, url: null}
+description: |-
+  Normalized ZZ fiducial cross section (multiplied by 10^6 for readability) in bins of deltaPhi between the two leptons of the leading dileptons for the 4l channel.  The first systematic uncertainty is detector systematics, the second is background systematic uncertainties.
+  UPDATE (30 APR 2014): extra significant digit added for first bin.
+keywords:
+- name: reactions
+  values: [P P --> Z0 Z0 X]
+- name: observables
+  values: [DSIG/DPHI]
+- name: phrases
+  values: []
+- name: cmenergies
+  values: [7000.0]
+location: Data from Figure 9A
+name: Table 5
+---
+additional_resources: []
+data_file: data6.yaml
+data_license: {description: null, name: null, url: null}
+description: Normalized ZZ fiducial cross section (multiplied by 10^6 for readability)
+  in bins of deltaPhi between the two leptons for the 2l2nu channel.  The first systematic
+  uncertainty is detector systematics, the second is background systematic uncertainties.
+keywords:
+- name: reactions
+  values: [P P --> Z0 Z0 X]
+- name: observables
+  values: [DSIG/DPHI]
+- name: phrases
+  values: []
+- name: cmenergies
+  values: [7000.0]
+location: Data from Figure 9B
+name: Table 6
+---
+additional_resources: []
+data_file: data7.yaml
+data_license: {description: null, name: null, url: null}
+description: Normalized ZZ fiducial cross section (multiplied by 10^6 for readability)
+  in bins of the mass of the ZZ system for the 4l channel.  The first systematic uncertainty
+  is detector systematics, the second is background systematic uncertainties.
+keywords:
+- name: reactions
+  values: [P P --> Z0 Z0 X]
+- name: observables
+  values: [DSIG/DM]
+- name: phrases
+  values: []
+- name: cmenergies
+  values: [7000.0]
+location: Data from Figure 10A
+name: Table 7
+---
+additional_resources: []
+data_file: data8.yaml
+data_license: {description: null, name: null, url: null}
+description: Normalized ZZ fiducial cross section (multiplied by 10^6 for readability)
+  in bins of the transverse mass of the ZZ system for the 2l2nu channel.  The first
+  systematic uncertainty is detector systematics, the second is background systematic
+  uncertainties.
+keywords:
+- name: reactions
+  values: [P P --> Z0 Z0 X]
+- name: observables
+  values: [DSIG/DM]
+- name: phrases
+  values: []
+- name: cmenergies
+  values: [7000.0]
+location: Data from Figure 10B
+name: Table 8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 future
 pyyaml
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-requests
+future
+pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-future
-pyyaml
-requests
+future==0.18.2
+pyyaml==5.3
+requests==2.23.0

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,5 @@
+docker run -d -p 0.0.0.0:8945:5000 --name hepdata-converter-ws-tests hepdata/hepdata-converter-ws
+sleep 1
+coverage run -m unittest discover hepdata_converter_ws_client/testsuite 'test_*'
+docker stop hepdata-converter-ws-tests
+docker container rm hepdata-converter-ws-tests

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=[
         'requests',
     ],
-    tests_require=['flask-testing', 'flask', 'hepdata-converter-ws'],
+    tests_require=['pyyaml'],
 
     packages=['hepdata_converter_ws_client'],
     url='https://github.com/HEPData/hepdata-converter-ws-client/',

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     name='hepdata-converter-ws-client',
     version=get_version(),
     install_requires=[
+        'future',
         'requests',
     ],
     tests_require=['pyyaml'],


### PR DESCRIPTION
It should still compatible with python2 as well.

Fixes #2 - see comments there and https://github.com/orgs/HEPData/projects/1#card-34125366 for details of changes to dependencies.